### PR TITLE
feat: add toast messages to Login and Register

### DIFF
--- a/src/components/Authenticate/Login.css
+++ b/src/components/Authenticate/Login.css
@@ -6,6 +6,19 @@
   float: left;
 }
 
+.site-form-item-icon {
+  margin-right: 5px;
+}
+
 .login-form-button {
   width: 100%;
+  margin-bottom: 10px;
+}
+
+.spin-container {
+  width: auto;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }

--- a/src/components/Authenticate/Login.js
+++ b/src/components/Authenticate/Login.js
@@ -1,8 +1,9 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { authActions, login } from './authSlice';
 import './Login.css';
+import { successToast, errorToast } from '../../helpers/messageToast';
 
-import { LockOutlined, UserOutlined, LoadingOutlined } from '@ant-design/icons';
+import { LockOutlined, MailOutlined, LoadingOutlined } from '@ant-design/icons';
 import { Button, Checkbox, Form, Input, Row, Col, Spin } from 'antd';
 import { Link, useNavigate } from 'react-router-dom';
 import { useEffect } from 'react';
@@ -10,7 +11,7 @@ import { useEffect } from 'react';
 const antIcon = (
   <LoadingOutlined
     style={{
-      fontSize: 24,
+      fontSize: 64,
     }}
     spin
   />
@@ -19,39 +20,53 @@ const antIcon = (
 export default function Login() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const [form] = Form.useForm();
 
-  const { user, isLoading, isSuccess, isError, message } = useSelector(
-    (state) => state.auth
-  );
+  const {
+    user,
+    isLoading,
+    isSuccess,
+    isError,
+    message: authStateMessage,
+  } = useSelector((state) => state.auth);
 
   const onFinish = (values) => {
     const userData = { ...values.user };
-    console.log('Logged in userData', userData);
     dispatch(login(userData));
   };
 
   useEffect(() => {
     if (isError) {
-      console.log(message);
+      errorToast(authStateMessage);
     }
-    if (isSuccess || user) {
+    if (isSuccess) {
+      navigate('/');
+      successToast(`Welcome, ${authStateMessage}`);
+    }
+    if (user) {
       navigate('/');
     }
     dispatch(authActions.reset());
-  }, [user, isError, isSuccess, message, navigate, dispatch]);
+  }, [user, isError, isSuccess, authStateMessage, navigate, dispatch]);
 
-  if (isLoading) return <Spin indicator={antIcon} />;
+  if (isLoading)
+    return (
+      <div className='spin-container'>
+        <Spin indicator={antIcon} tip='Loading...' />
+      </div>
+    );
 
   return (
     <Row align='middle' style={{ height: '100vh' }}>
       <Col span={6} offset={9}>
         <Form
+          form={form}
           name='login-user'
-          className='login-form'
           initialValues={{
             remember: true,
           }}
           onFinish={onFinish}
+          preserve
         >
           <Form.Item
             name={['user', 'email']}
@@ -64,7 +79,7 @@ export default function Login() {
             ]}
           >
             <Input
-              prefix={<UserOutlined className='site-form-item-icon' />}
+              prefix={<MailOutlined className='site-form-item-icon' />}
               placeholder='Email'
               data-cy='login-email-input'
             />
@@ -89,10 +104,6 @@ export default function Login() {
             <Form.Item name='remember' valuePropName='checked' noStyle>
               <Checkbox>Remember me</Checkbox>
             </Form.Item>
-
-            {/* <a className='login-form-forgot' href=''>
-              Forgot password
-            </a> */}
           </Form.Item>
 
           <Form.Item>

--- a/src/components/Authenticate/Register.js
+++ b/src/components/Authenticate/Register.js
@@ -1,7 +1,8 @@
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { authActions, register } from './authSlice';
+import { successToast, errorToast } from '../../helpers/messageToast';
 
 import {
   LockOutlined,
@@ -14,7 +15,7 @@ import { Button, Form, Input, Row, Col, Spin } from 'antd';
 const antIcon = (
   <LoadingOutlined
     style={{
-      fontSize: 24,
+      fontSize: 64,
     }}
     spin
   />
@@ -23,39 +24,54 @@ const antIcon = (
 export default function Register() {
   const navigate = useNavigate();
   const dispatch = useDispatch();
+  const [form] = Form.useForm();
 
-  const { user, isLoading, isSuccess, isError, message } = useSelector(
-    (state) => state.auth
-  );
+  const {
+    user,
+    isLoading,
+    isSuccess,
+    isError,
+    message: authStateMessage,
+  } = useSelector((state) => state.auth);
 
   const onFinish = (values) => {
     const userData = { ...values.user };
-    console.log('Registered form userData', userData);
     dispatch(register(userData));
   };
 
   useEffect(() => {
     if (isError) {
-      console.log(message);
+      errorToast(authStateMessage);
     }
-    if (isSuccess || user) {
+    if (isSuccess) {
+      navigate('/');
+      successToast(`Welcome, ${authStateMessage}`);
+    }
+    if (user) {
       navigate('/');
     }
-    dispatch(authActions.reset());
-  }, [user, isError, isSuccess, message, navigate, dispatch]);
 
-  if (isLoading) return <Spin indicator={antIcon} />;
+    dispatch(authActions.reset());
+  }, [user, isError, isSuccess, authStateMessage, navigate, dispatch]);
+
+  if (isLoading)
+    return (
+      <div className='spin-container'>
+        <Spin indicator={antIcon} tip='Loading...' />
+      </div>
+    );
 
   return (
     <Row align='middle' style={{ height: '100vh' }}>
       <Col span={6} offset={9}>
         <Form
+          form={form}
           name='register-user'
-          className='login-form'
           initialValues={{
             remember: true,
           }}
           onFinish={onFinish}
+          preserve={true}
         >
           <Form.Item
             name={['user', 'name']}
@@ -113,6 +129,9 @@ export default function Register() {
             >
               Register
             </Button>
+            <span>
+              Go back to <Link to='/login'>Login</Link>.
+            </span>
           </Form.Item>
         </Form>
       </Col>

--- a/src/components/Authenticate/authService.js
+++ b/src/components/Authenticate/authService.js
@@ -3,7 +3,6 @@ import axios from 'axios';
 const API_GET_LOGGED_USER = 'http://localhost:8080/api/getLoggedUser/';
 const API_REGISTER_USER = 'http://localhost:8080/api/user/';
 
-//register user
 const register = async (userData) => {
   const response = await axios.post(API_REGISTER_USER, userData, {
     headers: {
@@ -18,7 +17,6 @@ const register = async (userData) => {
   return response.data;
 };
 
-//login user
 const login = async (userData) => {
   const response = await axios.get(
     `${API_GET_LOGGED_USER}${userData.email}/?pwd=${userData.password}`

--- a/src/components/Authenticate/authSlice.js
+++ b/src/components/Authenticate/authSlice.js
@@ -18,13 +18,7 @@ export const register = createAsyncThunk(
     try {
       return await authService.register(user);
     } catch (error) {
-      const message =
-        (error.response &&
-          error.response.data &&
-          error.response.data.message) ||
-        error.message ||
-        error.toString();
-      return thunkAPI.rejectWithValue(message);
+      return thunkAPI.rejectWithValue(error.response.data);
     }
   }
 );
@@ -33,11 +27,7 @@ export const login = createAsyncThunk('auth/login', async (user, thunkAPI) => {
   try {
     return await authService.login(user);
   } catch (error) {
-    const message =
-      (error.response && error.response.data && error.response.data.message) ||
-      error.message ||
-      error.toString();
-    return thunkAPI.rejectWithValue(message);
+    return thunkAPI.rejectWithValue(error.response.data);
   }
 });
 
@@ -65,6 +55,7 @@ const authSlice = createSlice({
         state.isLoading = false;
         state.isSuccess = true;
         state.user = action.payload;
+        state.message = action.payload.name;
       })
       .addCase(register.rejected, (state, action) => {
         state.isLoading = false;
@@ -79,6 +70,7 @@ const authSlice = createSlice({
         state.isLoading = false;
         state.isSuccess = true;
         state.user = action.payload;
+        state.message = action.payload.name;
       })
       .addCase(login.rejected, (state, action) => {
         state.isLoading = false;

--- a/src/helpers/messageToast.js
+++ b/src/helpers/messageToast.js
@@ -1,0 +1,19 @@
+import { message } from 'antd';
+
+export const successToast = (msg) => {
+  message.success({
+    content: msg,
+    style: {
+      marginTop: '10vh',
+    },
+  });
+};
+
+export const errorToast = (msg) => {
+  message.error({
+    content: msg,
+    style: {
+      marginTop: '10vh',
+    },
+  });
+};


### PR DESCRIPTION
### Authentication Toasts
Am implementat mesaje tip toast din antd: https://ant.design/components/message/ .

Folosesc `isError` si `isSuccess` din `authSlice.js -> state`  pentru a produce mesaje (toasts) de eroare sau de succes la Login sau la Register.

### Form preserve
De asemenea, atunci cand apare o eroare dupa submit la Login sau la Register, valorile din input nu se mai reseteaza.